### PR TITLE
Fix bug with integer-like keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,14 @@ function isArray(obj) {
     Object.prototype.toString.call(obj) == '[object Array]';
 }
 
+function getKey(key) {
+  var intKey = parseInt(key);
+  if (intKey.toString() === key) {
+    return intKey;
+  }
+  return key;
+}
+
 
 
 function set(obj, path, value, doNotReplace) {
@@ -37,7 +45,7 @@ function set(obj, path, value, doNotReplace) {
   if(isString(path)) {
     return set(obj, path.split('.'), value, doNotReplace);
   }
-  var currentPath = isNaN(parseInt(path[0])) ? path[0] : parseInt(path[0]);
+  var currentPath = getKey(path[0]);
   if(path.length === 1) {
     var oldVal = obj[currentPath];
     if(oldVal === void 0 || !doNotReplace) {
@@ -91,7 +99,7 @@ objectPath.get = function(obj, path) {
   if(isString(path)) {
     return objectPath.get(obj, path.split('.'));
   }
-  var currentPath = isNaN(parseInt(path[0])) ? path[0] : parseInt(path[0]);
+  var currentPath = getKey(path[0]);
   if(path.length === 1) {
     return obj[currentPath];
   }

--- a/test.js
+++ b/test.js
@@ -38,6 +38,10 @@ describe('get', function() {
   it('should return undefined for missing values under array', function() {
     expect(objectPath.get(getTestObj(), "b.d.5")).to.not.exist;
   });
+
+  it('should return the value under integer-like key', function() {
+    expect(objectPath.get({ "1a": "foo" }, "1a")).to.be.equal("foo");
+  });
 });
 
 
@@ -69,7 +73,20 @@ describe('set', function() {
   it('should create intermediate arrays', function() {
     var obj = getTestObj();
     objectPath.set(obj, "c.0.1.m", "l");
+    expect(obj.c[0]).to.be.an("array");
     expect(obj).to.have.deep.property("c.0.1.m", "l");
+  });
+
+  it('should set value under integer-like key', function() {
+    var obj = getTestObj();
+    objectPath.set(obj, "1a", "foo");
+    expect(obj).to.have.deep.property("1a", "foo");
+  });
+
+  it('should set value under empty array', function() {
+    var obj = [];
+    objectPath.set(obj, [0], "foo");
+    expect(obj[0]).to.be.equal("foo");
   });
 });
 


### PR DESCRIPTION
Previously if `parseInt()` successfully parsed an integer value from a path, it was used, even if it didn't actually match the path. For example, with a path of `"123abc"` the integer value `123` was used.
