### PR TITLE
accept number type path, bump patch version, fix bower version, update tests for 100% coverage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "object-path",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "main": "index.js",
   "keywords": [
     "deep",

--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@
   }
 
   function set(obj, path, value, doNotReplace){
+    if (isNumber(path)) {
+      path = [path];
+    }
     if (isEmpty(path)) {
       return obj;
     }
@@ -95,11 +98,16 @@
   }
 
   function del(obj, path) {
+    if (isNumber(path)) {
+      path = [path];
+    }
+
+    if (isEmpty(obj)) {
+      return void 0;
+    }
+
     if (isEmpty(path)) {
       return obj;
-    }
-    if (isEmpty(obj)) {
-      return undefined;
     }
     if(isString(path)) {
       return del(obj, path.split('.'));
@@ -190,6 +198,9 @@
   };
 
   objectPath.get = function (obj, path, defaultValue){
+    if (isNumber(path)) {
+      path = [path];
+    }
     if (isEmpty(path)) {
       return obj;
     }
@@ -199,6 +210,7 @@
     if (isString(path)) {
       return objectPath.get(obj, path.split('.'), defaultValue);
     }
+
     var currentPath = getKey(path[0]);
 
     if (path.length === 1) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "object-path",
   "description": "Access deep properties using a path",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Mario Casciaro"
   },
@@ -14,11 +14,11 @@
     "node": ">=0.8.0"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
+    "mocha": "~1.20.1",
     "chai": "~1.9.1",
     "mocha-lcov-reporter": "~0.0.1",
-    "coveralls": "~2.10.0",
-    "istanbul": "~0.2.7"
+    "coveralls": "~2.11.1",
+    "istanbul": "~0.3.0"
   },
   "scripts": {
     "test": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha test.js --report html -- -R spec"

--- a/test.js
+++ b/test.js
@@ -21,6 +21,12 @@ describe('get', function() {
     expect(objectPath.get(obj, ["a"])).to.be.equal("b");
   });
 
+  it('should work with number path', function() {
+    var obj = getTestObj();
+    expect(objectPath.get(obj.b.d, 0)).to.be.equal("a");
+    expect(objectPath.get(obj.b, 0)).to.be.equal(void 0);
+  });
+
   it('should return the value under deep object', function() {
     var obj = getTestObj();
     expect(objectPath.get(obj, "b.f")).to.be.equal("i");
@@ -102,6 +108,12 @@ describe('set', function() {
     expect(obj).to.have.deep.property("c.m", "o");
   });
 
+  it('should set value using number path', function() {
+    var obj = getTestObj();
+    objectPath.set(obj.b.d, 0, "o");
+    expect(obj).to.have.deep.property("b.d.0", "o");
+  });
+
   it('should set value under deep object', function() {
     var obj = getTestObj();
     objectPath.set(obj, "b.c", "o");
@@ -178,6 +190,13 @@ describe('push', function() {
     objectPath.push(obj, ["b","h"], "l");
     expect(obj).to.have.deep.property("b.h.0", "l");
   });
+
+  it('should push value to existing array using number path', function() {
+    var obj = getTestObj();
+    objectPath.push(obj.b.e, 0, "l");
+    expect(obj).to.have.deep.property("b.e.0.0", "l");
+  });
+
 });
 
 
@@ -255,8 +274,8 @@ describe('coalesce', function(){
 describe('empty', function(){
   it('should ignore invalid arguments safely', function(){
     var obj = {};
-    expect(objectPath.empty()).to.equal(undefined);
-    expect(objectPath.empty(obj, 'path')).to.equal(undefined);
+    expect(objectPath.empty()).to.equal(void 0);
+    expect(objectPath.empty(obj, 'path')).to.equal(void 0);
     expect(objectPath.empty(obj, '')).to.equal(obj);
 
     obj.path = true;
@@ -323,7 +342,13 @@ describe('empty', function(){
 
 describe('del', function(){
   it('should return undefined on empty object', function(){
-    expect(objectPath.del({}, 'a')).to.equal(undefined);
+    expect(objectPath.del({}, 'a')).to.equal(void 0);
+  });
+
+  it('should work with number path', function(){
+    var obj = getTestObj();
+    objectPath.del(obj.b.d, 1);
+    expect(obj.b.d).to.deep.equal(['a']);
   });
 
   it('should delete deep paths', function(){


### PR DESCRIPTION
I stumbled upon this problem when tried to pass a number variable to `.get`. had to manually "wrap" it in an array because `0` is falsy, and was never being accepted as an string. this fixes the issue in all cases.
