### PR TITLE
Added tests: has, distinct nonexistent key and key is set to undefined.

### DIFF
--- a/test.js
+++ b/test.js
@@ -507,6 +507,14 @@ describe('has', function () {
     expect(objectPath.has(obj, '1a')).to.be.true;
     expect(objectPath.has(obj, ['1a'])).to.be.true;
   });
+
+  it('should distinct nonexistent key and key = undefined', function() {
+    var obj = {};
+    expect(objectPath.has(obj, 'key')).to.be.false;
+
+    obj.key = undefined;
+    expect(objectPath.has(obj, 'key')).to.be.true;
+  });
 });
 
 


### PR DESCRIPTION
This test is vital, because it is the one of important use-cases for `has`. On the other side `get` will return undefined in both cases, makes they indistinguishable.