### PR TITLE
remove deprecated node 0.8 and add iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10"
-  - "0.8"
+  - "iojs"
 after_success: "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"


### PR DESCRIPTION
Last release of node 0.8 was on 2013.06.13, before all the OpenSSL vulnerabilities... so let's not perpetuate this old vulnerable piece of software ;)