### PR TITLE
fixes bower mismatch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "object-path",
-  "version": "0.9.2",
   "main": "index.js",
   "keywords": [
     "deep",


### PR DESCRIPTION
```
bower mismatch      Version declared in the json (0.9.2) is different than the resolved one (0.9.3)
```

https://github.com/bower/bower.json-spec/tree/0b34d2bb0bdd4fa31fa9728f787f49e170e41f99#version

>Intended to be used in the future when Bower gets a real registry where you can publish actual packages, but for now just leave it out.