### PR TITLE
Accessing non-enumerable properties with object-path

### DIFF
--- a/test.js
+++ b/test.js
@@ -66,6 +66,11 @@ describe('get', function() {
     expect(objectPath.get(obj, ['b','e',1,'f'])).to.be.equal('g');
   });
 
+  it('should return the array length', function() {
+    var obj = getTestObj();
+    expect(objectPath.get(obj, 'b.c.length')).to.be.equal(0);
+  });
+
   it('should return undefined for missing values under object', function() {
     var obj = getTestObj();
     expect(objectPath.get(obj, 'a.b')).to.not.exist;


### PR DESCRIPTION
Hey Mario, 

The following test case yielded unexpected results for me: 

````javascript
var path = require("object-path")

var obj = {
  arr: [],
  b: {
    a: [],
    c: {}
  }
};

console.log(path.get(obj, 'arr'))             // []
console.log(path.get(obj, 'arr.length'))      // undefined
console.log(path.get(obj, 'b'))               // { a:[], c: {} }
````

I believe it's down to accessing non-enumerable properties using object-path. I've included a failing test case in the PR. Just highlighting it in case anyone else runs into the issue!

