### PR TITLE
global argument fallback to window

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-(function (root, factory){
+(function (global, factory){
   'use strict';
 
   /*istanbul ignore next:cant test*/
@@ -9,9 +9,9 @@
     define([], factory);
   } else {
     // Browser globals
-    root.objectPath = factory();
+    global.objectPath = factory();
   }
-})(this, function(){
+})(this || window, function(){
   'use strict';
 
   var


### PR DESCRIPTION
I always use this module in nodejs environment. But now I'm trying to use directly in the browser but for some reason the objectPath function is not globally available in Chrome, although in Firefox is available.