### PR TITLE
added key:value notation support to getShallowProperty()

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@
             var v = getShallowProperty(e, idField);
             if (v == idValue)
             {
-              console.log(`Found item where ${idField}=${idValue}`);
+              //console.log(`Found item where ${idField}=${idValue}`);
               return e;
             }
           }
@@ -144,7 +144,7 @@
         }
       }
 
-      return set(obj[currentPath], path.slice(1), value, doNotReplace);
+      return set(currentValue, path.slice(1), value, doNotReplace);
     }
 
     objectPath.has = function (obj, path) {

--- a/index.js
+++ b/index.js
@@ -88,8 +88,31 @@
     }
 
     function getShallowProperty(obj, prop) {
-      if (hasShallowProperty(obj, prop)) {
+      if (typeof prop === 'number')
         return obj[prop];
+
+      var parts = prop.split(':');
+      var isArray = Array.isArray(obj);
+      //console.log(`prop=${prop} parts.length=${parts.length} isArray=${isArray} parts[0]=${parts[0]}`);
+      if (parts.length == 1) {
+        if (hasShallowProperty(obj, prop)) {
+          return obj[prop];
+        }
+      }
+      if (isArray) {
+        var idField = parts[0];
+        var idValue = parts[1];
+        for (var i = 0; i < obj.length; i++) {
+          var e = obj[i];
+          if (hasShallowProperty(e, idField)) {
+            var v = getShallowProperty(e, idField);
+            if (v == idValue)
+            {
+              console.log(`Found item where ${idField}=${idValue}`);
+              return e;
+            }
+          }
+        }
       }
     }
 
@@ -245,7 +268,7 @@
         return nextObj;
       }
 
-      return objectPath.get(obj[currentPath], path.slice(1), defaultValue);
+      return objectPath.get(nextObj, path.slice(1), defaultValue);
     };
 
     objectPath.del = function del(obj, path) {

--- a/index.js
+++ b/index.js
@@ -88,18 +88,17 @@
     }
 
     function getShallowProperty(obj, prop) {
-      if (typeof prop === 'number')
+      if (typeof prop === 'number') {
         return obj[prop];
+      }
+      if (hasShallowProperty(obj, prop)) {
+        return obj[prop];
+      }
 
       var parts = prop.split(':');
       var isArray = Array.isArray(obj);
       //console.log(`prop=${prop} parts.length=${parts.length} isArray=${isArray} parts[0]=${parts[0]}`);
-      if (parts.length == 1) {
-        if (hasShallowProperty(obj, prop)) {
-          return obj[prop];
-        }
-      }
-      if (isArray) {
+      if (parts.length == 2 && isArray) {
         var idField = parts[0];
         var idValue = parts[1];
         for (var i = 0; i < obj.length; i++) {
@@ -142,6 +141,7 @@
         } else {
           obj[currentPath] = {};
         }
+        currentValue = obj[currentPath];
       }
 
       return set(currentValue, path.slice(1), value, doNotReplace);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "object-path-key-value",
   "description": "Access deep object properties using a path, including key:value array-search support",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "author": {
     "name": "Mario Casciaro, fork by Tilfried uTILLIty Weissenberger"
   },

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "object-path",
-  "description": "Access deep object properties using a path",
-  "version": "0.11.4",
+  "name": "object-path-key-value",
+  "description": "Access deep object properties using a path, including key:value array-search support",
+  "version": "0.11.6",
   "author": {
-    "name": "Mario Casciaro"
+    "name": "Mario Casciaro, fork by Tilfried uTILLIty Weissenberger"
   },
-  "homepage": "https://github.com/mariocasciaro/object-path",
+  "homepage": "https://github.com/utillity/object-path",
   "repository": {
     "type": "git",
-    "url": "git://github.com/mariocasciaro/object-path.git"
+    "url": "https://github.com/utillity/object-path.git"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test.js
+++ b/test.js
@@ -141,6 +141,12 @@ describe('get', function() {
     expect(objectPath.get(extended, 'enabled')).to.be.equal(true);
     expect(objectPath.get(extended, 'one')).to.be.equal(undefined);
   });
+
+  it('should return the object by key-field', function() {
+    var obj = getComplexTestObj();
+    expect(objectPath.get(obj, 'personas.id:def.name')).to.be.equal('Mike');
+    expect(objectPath.get(obj, ['personas', 'id:def', 'name'])).to.be.equal('Mike');
+  });
 });
 
 
@@ -243,6 +249,12 @@ describe('set', function() {
     obj = [];
     objectPath.set(obj, '0', 'foo');
     expect(obj[0]).to.be.equal('foo');
+  });
+
+  it('should set by key-field', function() {
+    var obj = getComplexTestObj();
+    objectPath.set(obj, 'personas.id:def.name', 'Peter');
+    expect(obj.personas[1].name).to.be.equal('Peter');
   });
 });
 
@@ -952,11 +964,5 @@ describe('Access own properties [optional]', function () {
     objectPath.withInheritedProps.del(obj, 'notOwn');
     //expect(proto).to.be.deep.equal({notOwn: {}});
     //expect(obj).to.be.deep.equal({notOwn: {}});
-  });
-
-  it('should return the object by key-field', function() {
-    var obj = getComplexTestObj();
-    expect(objectPath.get(obj, 'personas.id:def.name')).to.be.equal('Mike');
-    expect(objectPath.get(obj, ['personas', 'id:def', 'name'])).to.be.equal('Mike');
   });
 });

--- a/test.js
+++ b/test.js
@@ -15,6 +15,15 @@ function getTestObj() {
   };
 }
 
+function getComplexTestObj() {
+  return {
+    "personas": [
+         { "id":"abc", "name":"John" }, 
+         { "id":"def", "name":"Mike" }
+     ]
+ };
+}
+
 describe('get', function() {
   it('should return the value using unicode key', function() {
     var obj = {
@@ -395,9 +404,9 @@ describe('empty', function(){
       this.notOwn = true;
     }
 
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     Instance.prototype.test = function(){};
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     Instance.prototype.arr = [];
 
     var
@@ -417,7 +426,7 @@ describe('empty', function(){
         instance: new Instance()
       };
 
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     obj['function'] = function(){};
 
     objectPath.empty(obj, ['array','2']);
@@ -728,9 +737,9 @@ describe('bind object', function () {
       this.notOwn = true;
     }
 
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     Instance.prototype.test = function(){};
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     Instance.prototype.arr = [];
 
     var
@@ -748,7 +757,7 @@ describe('bind object', function () {
         instance: new Instance()
       };
 
-    /*istanbul ignore next: not part of code */
+    //istanbul ignore next: not part of code
     obj['function'] = function(){};
 
     var model = objectPath(obj);
@@ -943,5 +952,11 @@ describe('Access own properties [optional]', function () {
     objectPath.withInheritedProps.del(obj, 'notOwn');
     //expect(proto).to.be.deep.equal({notOwn: {}});
     //expect(obj).to.be.deep.equal({notOwn: {}});
+  });
+
+  it('should return the object by key-field', function() {
+    var obj = getComplexTestObj();
+    expect(objectPath.get(obj, 'personas.id:def.name')).to.be.equal('Mike');
+    expect(objectPath.get(obj, ['personas', 'id:def', 'name'])).to.be.equal('Mike');
   });
 });


### PR DESCRIPTION
added key:value notation support to getShallowProperty(), allowing to get a specific array-entry identified by key:value pair